### PR TITLE
Read `agent.conf` to extract statepassword

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/juju/rebootstrap-raft
 
-go 1.23.7
+go 1.24
+
+toolchain go1.24.1
 
 require (
+	github.com/hashicorp/go-hclog v1.6.2
 	github.com/hashicorp/raft v1.7.2
 	github.com/hashicorp/raft-boltdb v0.0.0-20250225060035-8f7048cdfa53
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
@@ -11,13 +14,13 @@ require (
 	github.com/juju/loggo v1.0.0
 	github.com/juju/mgo/v2 v2.0.0-20210302023703-70d5d206e208
 	github.com/juju/replicaset v0.0.0-20210302050932-0303c8575745
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/hashicorp/go-hclog v1.6.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
 	github.com/hashicorp/go-metrics v0.5.4 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect

--- a/src/rebootstrap-raft/getmachineid_test.go
+++ b/src/rebootstrap-raft/getmachineid_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+type dirEntry struct {
+	name  string
+	isDir bool
+}
+
+func populateAgentDir(tempDir string, dirEntries []dirEntry) (string, error) {
+	var err error
+	for _, entry := range dirEntries {
+		if entry.isDir {
+			err = os.Mkdir(tempDir+"/"+entry.name, 0755)
+		} else {
+			_, err = os.Create(tempDir + "/" + entry.name)
+		}
+		if err != nil {
+			break
+		}
+	}
+	return tempDir, err
+}
+
+func TestMissingAgentDirectory(t *testing.T) {
+	agentDir, err := populateAgentDir(t.TempDir(), []dirEntry{})
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %s", err)
+	}
+	command := &rebootstrapCommand{}
+	// In order to test whether we catch a missing directory, we create a valid agentDir
+	// and then reference a missing directory inside it.
+	_, err = command.getMachineID(agentDir + "/missing")
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		t.Errorf("Expected an error for missing agent directory, got %s", err)
+	}
+}
+
+func TestGetID(t *testing.T) {
+	agentDir, err := populateAgentDir(t.TempDir(), []dirEntry{
+		{name: "machine-0", isDir: true},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %s", err)
+	}
+	command := &rebootstrapCommand{}
+	machineID, err := command.getMachineID(agentDir)
+	if err != nil {
+		t.Errorf("Expected no error, got %s", err)
+	}
+	if machineID != "0" {
+		t.Errorf("Expected machine ID to be '0', got %s", machineID)
+	}
+}
+
+func TestMultipleMachineIDs(t *testing.T) {
+	agentDir, err := populateAgentDir(t.TempDir(), []dirEntry{
+		{name: "machine-0", isDir: true},
+		{name: "machine-1", isDir: true},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %s", err)
+	}
+	command := &rebootstrapCommand{}
+	machineID, err := command.getMachineID(agentDir)
+	if err == nil {
+		t.Errorf("Expected an error for multiple machine IDs, got %s", machineID)
+	}
+	if err.Error() != "expected exactly one machine ID, got 2" {
+		t.Errorf("Expected error 'multiple machine IDs found', got %s", err)
+	}
+}
+
+func TestGetIDWithFile(t *testing.T) {
+	agentDir, err := populateAgentDir(t.TempDir(), []dirEntry{
+		{name: "machine-0", isDir: true},
+		{name: "machine-1", isDir: false},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %s", err)
+	}
+	command := &rebootstrapCommand{}
+	machineID, err := command.getMachineID(agentDir)
+	if err != nil {
+		t.Errorf("Expected no error, got %s", err)
+	}
+	if machineID != "0" {
+		t.Errorf("Expected machine ID to be '0', got %s", machineID)
+	}
+}

--- a/src/rebootstrap-raft/getstatepassword_test.go
+++ b/src/rebootstrap-raft/getstatepassword_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGetStatePasswordMissingFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "test-agents-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+	command := &rebootstrapCommand{}
+	_, err = command.getStatePassword("0", tempDir+"/missing")
+	if err == nil {
+		t.Errorf("Expected 'file not found' error")
+	}
+	if !strings.Contains(err.Error(), "no such file") {
+		t.Errorf("Expected file not found error, got %v", err)
+	}
+}
+
+func TestGetStatePassword(t *testing.T) {
+	statefile := strings.NewReader(`# format 2.0
+tag: machine-0
+datadir: /var/lib/juju
+transient-datadir: /var/run/juju
+logdir: /var/log/juju
+metricsspooldir: /var/lib/juju/metricspool
+nonce: user-admin:bootstrap
+jobs:
+- JobManageModel
+- JobHostUnits
+upgradedToVersion: 2.9.51
+statepassword: qKoU8Y/BRQd0shDFA4OdHxlf
+controller: controller-e5e3d855-9df1-4e24-8010-0bfa6bc3cbf1
+model: model-a03dcd4f-afaf-4c96-8965-f2537e3b4873
+apiaddresses:
+- 10.1.20.117:17070
+- '[fd42::216:3eff:fe69:bb55]:17070'
+apipassword: qKoU8Y/BRQd0shDFA4OdHxlf
+oldpassword: 8e2e2bdb1e690dcee14c381bbe92baf5
+loggingconfig: <root>=INFO; unit=DEBUG
+values:
+  AGENT_SERVICE_NAME: jujud-machine-0
+  CONTAINER_TYPE: ""
+  NUMA_CTL_PREFERENCE: "false"
+  PROVIDER_TYPE: lxd
+agent-logfile-max-size: 100
+agent-logfile-max-backups: 2
+apiport: 17070
+stateport: 37017
+mongoversion: 4.4.24/wiredTiger
+mongomemoryprofile: default
+juju-db-snap-channel: 4.4/stable`)
+	command := &rebootstrapCommand{}
+	password, err := command.extractStatePassword(statefile)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if password != "qKoU8Y/BRQd0shDFA4OdHxlf" {
+		t.Errorf("Expected empty password, got %s", password)
+	}
+}


### PR DESCRIPTION
This change makes the `--machine-id` and `--password` command line
arguments optional. If either is not given, the command will now try to
extract that information from the Juju machine agent directory on the
unit.

Fixes: https://github.com/juju/rebootstrap-raft/issues/2
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>