### PR TITLE
Create snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,32 @@
+name: rebootstrap-raft
+base: core24
+adopt-info: rebootstrap-raft
+summary: Recovery tool for broken Juju raft clusters
+description: |
+  This is my-snap's description. You have a paragraph or two to tell the
+  most important story about your snap. Keep it under 100 words though,
+  we live in tweetspace and your description wants to look good in the snap
+  store.
+
+grade: stable
+confinement: strict
+
+apps:
+  rebootstrap-raft:
+    command: bin/rebootstrap-raft
+
+parts:
+  rebootstrap-raft:
+    plugin: go
+    source: .
+    build-environment:
+      # Disable CGO so that we get a static binary
+      - CGO_ENABLED: "0"
+    build-snaps:
+      - go
+    build-packages:
+      - git
+    override-pull: |
+      set -e -u -x
+      craftctl default
+      craftctl set version=$(git describe --tags)


### PR DESCRIPTION
Because the app binary will link dynamically to glibc, care has to be
taken to match glibc version between the build host and the OS on the
controller unit. In particular, there is a breaking change in glibc
around Focal that prevents a binary compiled on a more recent Ubuntu
version from running on an older Ubuntu version, e.g. building on
Oracular, running on Bionic.

The snap provides a consistent run-time environment that prevents this
issue.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>